### PR TITLE
ci: use secrets: inherit and remove redundant permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,12 +6,7 @@ on:
       - main
       - release-please--branches--main**
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     uses: netwerk-digitaal-erfgoed/workflows/.github/workflows/release-please.yml@main
-    secrets:
-      token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
Switch release-please to secrets: inherit and remove redundant permissions block (already declared in shared workflow).