### PR TITLE
ci: publish on release, not on every push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Publish
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types:
+      - published
 
 jobs:
   publish:


### PR DESCRIPTION
Match the schema-profile repo pattern: only publish when release-please creates an actual release, not on every merge to main. Prevents publishing with in-progress version state.